### PR TITLE
add shouldComponentUpdate optimize renderer board childrens;

### DIFF
--- a/src/components/board/Piece.js
+++ b/src/components/board/Piece.js
@@ -45,6 +45,22 @@ export default class Piece extends Component {
     onSelected(position);
   };
 
+  // verify if piece has move before authorize new renderer
+  shouldComponentUpdate(nextProps, nextState) {
+
+    // check props dependencies of piece renderer
+    const {rowIndex, columnIndex, reverseBoard, type, color} = nextProps;
+
+    return (
+      rowIndex !== this.props.rowIndex ||
+      columnIndex !== this.props.columnIndex ||
+      reverseBoard !== this.props.reverseBoard ||
+      type !== this.props.type ||
+      color !== this.props.color
+    );
+
+  }
+
   render() {
     const {
       type,

--- a/src/components/board/Square.js
+++ b/src/components/board/Square.js
@@ -91,6 +91,22 @@ export default class Board extends Component {
     return null;
   }
 
+  // verify if square is update before authorize new renderer
+  shouldComponentUpdate(nextProps, nextState) {
+
+    // check props dependencies square renderer
+    const {selected, lastMove, canMoveHere, inCheck, reverseBoard} = nextProps;
+
+    return (
+      selected !== this.props.selected ||
+      lastMove !== this.props.lastMove ||
+      canMoveHere !== this.props.canMoveHere ||
+      inCheck !== this.props.inCheck ||
+      reverseBoard !== this.props.reverseBoard
+    );
+
+  }
+
   render() {
     const {
       size,


### PR DESCRIPTION
Added lifecycle method [shouldComponentUpdate(nextProps, nextState): boolean](https://reactjs.org/docs/react-component.html#shouldcomponentupdate) from files `./src/components/Piece.js` and  `./src/components/Square.js` because call `setState` from `./src/components/Board.js` hightweight renderer all Square and all Piece and cause *latency* user interface between **press event** and upgrade user interface.

[Screenshot logs](https://pasteboard.co/K6t4irr.png) during press event of any piece board **before** implement `shouldComponentUpdate`

[Screenshot logs](https://pasteboard.co/K6t3vGI.png) during press event of any piece board **after** implement `shouldComponentUpdate`


Thanks for your work.